### PR TITLE
Fix black-on-black text color issues

### DIFF
--- a/css/style2.css
+++ b/css/style2.css
@@ -16,6 +16,11 @@ a:link:hover, a:visited:hover {
     text-decoration: underline;
 }
 
+html {
+    color: #333;
+    background: #fff;
+}
+
 body {
     font-family: 'Open Sans', sans-serif;
     margin: 0;


### PR DESCRIPTION
Using Firefox with a dark GTK theme, I sometimes run into issues where the author has not set a default background and foreground color. When later in the stylesheet a color is chosen (often black) and a background is _not_ specified (under an assumption that all user agents are running white backgrounds), you will end up with black-on-black text which is obviously quite difficult to read. The solution is to set a background and color on the document.